### PR TITLE
Add separation between study type and area

### DIFF
--- a/partials/education.hbs
+++ b/partials/education.hbs
@@ -28,6 +28,9 @@
       <span class="studyType">{{studyType}}</span>
       {{/if}}
       {{#if area}}
+      {{#if studyType}}
+      &mdash;
+      {{/if}}
       <span class="area">{{area}}</span>
       {{/if}}
       {{#if gpa}}


### PR DESCRIPTION
This is especially important with some combinations like “Bachelor of Science Computer Science” which look weird because of the repetition, but other combinations also work better with some sort of separation there.