### PR TITLE
Make profile URLs links in print media

### DIFF
--- a/partials/basics.hbs
+++ b/partials/basics.hbs
@@ -63,7 +63,7 @@
       {{#if username}}
       <span class="username">
         {{#if url}}
-        {{url}}
+        <a href="{{url}}" target="external">{{url}}</a>
         {{/if}}
       </span>
       {{/if}}


### PR DESCRIPTION
This might seem useless but it means if you make a PDF version, the links are clickable in the PDF file.